### PR TITLE
Make UpdateAuthorNickname to automatically overwrite Author's nickname on conflict

### DIFF
--- a/src/main/java/lt/vu/persistence/AuthorsDAO.java
+++ b/src/main/java/lt/vu/persistence/AuthorsDAO.java
@@ -5,12 +5,19 @@ import lt.vu.entities.Author;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
+import javax.persistence.SynchronizationType;
+import javax.transaction.Transactional;
 import java.util.List;
 
 @ApplicationScoped
 public class AuthorsDAO {
     @Inject
     private EntityManager em;
+
+    @PersistenceUnit(name = "BooksPU")
+    EntityManagerFactory emf;
 
     public List<Author> loadAll() {
         return em.createNamedQuery("Author.findAll", Author.class).getResultList();
@@ -24,7 +31,18 @@ public class AuthorsDAO {
         this.em.persist(author);
     }
 
-    public Author update(Author author) {
-        return em.merge(author);
+    public void update(Author author) {
+        em.merge(author);
+    }
+
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public void overwriteAfterConflict(Author author) {
+        // construct a new EntityManager, because old persistence context was destroyed
+        EntityManager em = emf.createEntityManager(SynchronizationType.SYNCHRONIZED);
+
+        Author conflictingAuthor = em.find(Author.class, author.getId());
+        author.setVersion(conflictingAuthor.getVersion());
+        em.merge(author);
+        em.flush();
     }
 }

--- a/src/main/java/lt/vu/usecases/UpdateAuthorNickname.java
+++ b/src/main/java/lt/vu/usecases/UpdateAuthorNickname.java
@@ -37,7 +37,8 @@ public class UpdateAuthorNickname implements Serializable {
         try{
             authorsDAO.update(this.author);
         } catch (OptimisticLockException e) {
-            return "/author.xhtml?faces-redirect=true&authorId=" + this.author.getId() + "&error=optimistic-lock-exception";
+            this.author.setNickname("nickname after conflict resolution");
+            authorsDAO.overwriteAfterConflict(this.author);
         }
         return "/index.xhtml";
     }


### PR DESCRIPTION
**not intended to be merged**: This is merely an example on how that could be done (not saying it should :])

The main idea behind this is that if we want to **automatically** recover from an OLE in the same request we need:
1. To start a new transaction
2. To create a new EntityManager(because the old persistence context was destroyed on previous transaction rollback)
3. To manually update and merge the `version` field of an old entity(Author in this case) into a new persistence context 

